### PR TITLE
feat(filter): added filter to set tag type globally

### DIFF
--- a/just-rwd-functions.php
+++ b/just-rwd-functions.php
@@ -21,7 +21,10 @@ use jri\models\RwdImage;
  * @param string           $tag Specify which tag should be used: picture|img.
  * @param array            $attr  Additional html attributes to be used for main tag.
  */
-function rwd_attachment_image( $attachment = null, $size = 'thumbnail', $tag = 'picture', $attr = array() ) {
+function rwd_attachment_image( $attachment = null, $size = 'thumbnail', $tag, $attr = array() ) {
+	if(empty($tag)) {
+		$tag = apply_filters( 'rwd_tag_type', 'picture' );
+	}
 	echo get_rwd_attachment_image( $attachment, $size, $tag, $attr );
 }
 
@@ -41,9 +44,8 @@ function rwd_attachment_image( $attachment = null, $size = 'thumbnail', $tag = '
  *
  * @return string Generated html.
  */
-function get_rwd_attachment_image( $attachment = null, $size = 'thumbnail', $tag = 'picture', $attr = array() ) {
+function get_rwd_attachment_image( $attachment = null, $size = 'thumbnail', $tag, $attr = array() ) {
 	$rwd_image = new RwdImage( $attachment );
-
 	$size = apply_filters( 'post_thumbnail_size', $size );
 
 	if ( 'img' != $tag ) {

--- a/just-rwd-functions.php
+++ b/just-rwd-functions.php
@@ -22,7 +22,7 @@ use jri\models\RwdImage;
  * @param array            $attr  Additional html attributes to be used for main tag.
  */
 function rwd_attachment_image( $attachment = null, $size = 'thumbnail', $tag, $attr = array() ) {
-	if(empty($tag)) {
+	if( empty( $tag ) ) {
 		$tag = apply_filters( 'rwd_tag_type', 'picture' );
 	}
 	echo get_rwd_attachment_image( $attachment, $size, $tag, $attr );
@@ -46,6 +46,11 @@ function rwd_attachment_image( $attachment = null, $size = 'thumbnail', $tag, $a
  */
 function get_rwd_attachment_image( $attachment = null, $size = 'thumbnail', $tag, $attr = array() ) {
 	$rwd_image = new RwdImage( $attachment );
+
+	if( empty( $tag ) ) {
+		$tag = apply_filters( 'rwd_tag_type', 'picture' );
+	}
+
 	$size = apply_filters( 'post_thumbnail_size', $size );
 
 	if ( 'img' != $tag ) {

--- a/just-rwd-functions.php
+++ b/just-rwd-functions.php
@@ -21,7 +21,7 @@ use jri\models\RwdImage;
  * @param string           $tag Specify which tag should be used: picture|img.
  * @param array            $attr  Additional html attributes to be used for main tag.
  */
-function rwd_attachment_image( $attachment = null, $size = 'thumbnail', $tag, $attr = array() ) {
+function rwd_attachment_image( $attachment = null, $size = 'thumbnail', $tag = null, $attr = array() ) {
 	if( empty( $tag ) ) {
 		$tag = apply_filters( 'rwd_tag_type', 'picture' );
 	}
@@ -44,7 +44,7 @@ function rwd_attachment_image( $attachment = null, $size = 'thumbnail', $tag, $a
  *
  * @return string Generated html.
  */
-function get_rwd_attachment_image( $attachment = null, $size = 'thumbnail', $tag, $attr = array() ) {
+function get_rwd_attachment_image( $attachment = null, $size = 'thumbnail', $tag = null, $attr = array() ) {
 	$rwd_image = new RwdImage( $attachment );
 
 	if( empty( $tag ) ) {


### PR DESCRIPTION
This PR adds a filter to set the tag for the function `rwd_attachment_image`. It allows theme developers to set a default tag type whether it is `picture` or `img`. 

Themes can override by doing this:
```
function override_jri_tag_type() {
    return 'img';
}

add_filter('rwd_tag_type', 'override_jri_tag_type');
```